### PR TITLE
W4YCMS-12568: fix paypal lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "world4you/paypal-sdk-core-php": "3.4.0"
+        "world4you/paypal-sdk-core-php": "3.4.1"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "world4you/paypal-sdk-core-php": "3.4.1"
+        "world4you/paypal-sdk-core-php": "^3.4.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Laut Ticket W4YCMS-12568 ist die Paypal lib zu fixen. 

Der Fehler ist bereits behoben. 
Im Sentry wird darauf hingewiesen, dass im `lib/PayPal/Core/PPXmlMessage.php:124`

`parent::init(...)` einen Fehler wirft, wegen dem statischen Zugriff.

Das wurde bereits von Dave auf  `$this->init(...)` geändert.

Die Änderungen sind nicht im CMS, da noch php-sdk-code-php Version 3.4.0 installiert ist und diese Version
von paypal-merchant-sdk-php und paypal-permission-sdk-php required wird.